### PR TITLE
Fix wrong usage of width for non-adapted boxes

### DIFF
--- a/lua/comment-box/init.lua
+++ b/lua/comment-box/init.lua
@@ -176,7 +176,7 @@ local function format_lines(text)
 				final_box_width = vim.fn.strdisplaywidth(str) + 2
 			end
 		else
-			final_box_width = math.max(url_width, settings.doc_width - 2)
+			final_box_width = math.max(url_width, settings.box_width - 2)
 		end
 
 		if vim.fn.strdisplaywidth(str) > final_box_width then


### PR DESCRIPTION
When the adapted box is not used do not keep using document width, fallback to possibly user-specified box_width.

@amaanq, I think your last commit introduced this change. Can you please leave a comment about my pull request? I am afraid that I might be missing something that was in your last commit.