### PR TITLE
Fixed "Not an editor command"

### DIFF
--- a/lua/comment-box/catalog_view.lua
+++ b/lua/comment-box/catalog_view.lua
@@ -33,7 +33,7 @@ end
 local function view()
 	vim.api.nvim_buf_set_option(buf, "modifiable", true)
 	local cat_path = vim.api.nvim_get_runtime_file("catalog/catalog.txt", false)[1]
-	vim.api.nvim_command("$read" .. cat_path)
+	vim.api.nvim_command("$read " .. cat_path)
 	vim.api.nvim_buf_set_option(0, "modifiable", false)
 end
 


### PR DESCRIPTION
The missing whitespace made Neovim treat the whole string as a command, it was giving me problem on my Windows machine, not sure if this is related to the OS.