### PR TITLE
Update README + doc by adding suggested mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,22 @@ The symbols used to draw the lines. Let your creativity go wild! Or just use the
 
 Self explanatory!
 
+## Tips
+
+### Suggested mappings
+
+You can create a mapping for jumping to the next comment box like this:
+
+```lua
+-- map ]b [b to go to next block comment
+vim.keymap.set('n', ']b', '/\\S\\zs\\s*╭<CR>zt')
+vim.keymap.set('n', '[b', '?\\S\\zs\\s*╭<CR>zt')
+```
+
+This matches the first non-whitespace character in a line that precedes a comment box corner piece, ignoring any whitespace in between, and redraws the screen with the comment box at the top.
+
+Note: this example only works for the default rounded box shape. To match a different type of box, replace `╭` with the top-left corner piece of your preferred box type, e.g. `┌` for the classic box shape.
+
 ## Acknowledgement
 
 I learned and borrow from those plugins' code:

--- a/doc/comment-box.txt
+++ b/doc/comment-box.txt
@@ -40,7 +40,7 @@ CONTENTS                                                    *comment-box-content
         7.5. 'line_width'.................................|comment-box-line_width|
         7.6. 'lines'...........................................|comment-box-lines|
         7.7. 'outer_blank_lines'...................|comment-box-outer_blank_lines|
-        7.8 'inner_blank_lines'....................|comment-box-inner_blank_lines|
+        7.8. 'inner_blank_lines'...................|comment-box-inner_blank_lines|
         7.9. 'line_blank_line_above'...........|comment-box-line_blank_line_above|
         7.10 'line_blank_line_below'...........|comment-box-line_blank_line_below|
     8. Acknowledgement...............................|comment-box-acknowledgement|
@@ -106,7 +106,7 @@ QUICK START                                                          *quick-star
 
 
 
-If the plugin has tons of commands, you'll most likely need 3 or 4 at most on a 
+If the plugin has tons of commands, you'll most likely need 3 or 4 at most on a
 regular basis.
 - You'll probably want a box for titles. I personally choose a centered fixed box
   with text centered :CBccbox
@@ -509,7 +509,7 @@ Note: in addition to the usual way of closing windows, you can simply use `q` to
 close the catalog.
 
 The type n°1 for the box and line is the default one, so, if you didn't change
-the default settings via the `setup()` function (see 
+the default settings via the `setup()` function (see
 |comment-box-configuration|), passing nothing or 1 (or even 0) will lead to the
 same result.
 

--- a/doc/comment-box.txt
+++ b/doc/comment-box.txt
@@ -43,9 +43,11 @@ CONTENTS                                                    *comment-box-content
         7.8. 'inner_blank_lines'...................|comment-box-inner_blank_lines|
         7.9. 'line_blank_line_above'...........|comment-box-line_blank_line_above|
         7.10 'line_blank_line_below'...........|comment-box-line_blank_line_below|
-    8. Acknowledgement...............................|comment-box-acknowledgement|
-    9. About...................................................|comment-box-about|
-   10. License...............................................|comment-box-license|
+    8. Tips.....................................................|comment-box-tips|
+        8.1. Suggested mappings...................|comment-box-suggested_mappings|
+    9. Acknowledgement...............................|comment-box-acknowledgement|
+   10. About...................................................|comment-box-about|
+   11. License...............................................|comment-box-license|
 
 
 --------------------------------------------------------------------------------
@@ -605,6 +607,22 @@ Insert a blank line above the drawn line.
 'line_blank_line_below'                        *comment-box-line_blank_line_below*
 
 Insert a blank line below the drawn line.
+
+--------------------------------------------------------------------------------
+TIPS                                                          *comment-box-tips*
+
+SUGGESTED MAPPINGS                              *comment-box-suggested_mappings*
+
+You can create a mapping for jumping to the next comment box like this:
+>
+    -- map ]b [b to go to next block comment
+    vim.keymap.set('n', ']b', '/\\S\\zs\\s*╭<CR>zt')
+    vim.keymap.set('n', '[b', '?\\S\\zs\\s*╭<CR>zt')
+<
+
+This matches the first non-whitespace character in a line that precedes a comment box corner piece, ignoring any whitespace in between, and redraws the screen with the comment box at the top.
+
+Note: this example only works for the default rounded box shape. To match a different type of box, replace `╭` with the top-left corner piece of your preferred box type, e.g. `┌` for the classic box shape.
 
 --------------------------------------------------------------------------------
 ABOUT                                                         *comment-box-about*


### PR DESCRIPTION
I found that I often wanted to jump to the next or previous comment box when editing files, so I created a simple mapping that works for the default box shape and wanted to share that idea in case anyone else might find it useful.